### PR TITLE
Actualiza versión del paquete a 2.5.2

### DIFF
--- a/src/Sekure/Sekure.csproj
+++ b/src/Sekure/Sekure.csproj
@@ -6,7 +6,7 @@
     <Copyright>2025</Copyright>
     <PackageTags>Insurance</PackageTags>
     <PackageIcon>logo.png</PackageIcon>
-    <Version>2.5.1</Version>
+    <Version>2.5.2</Version>
     <Description>Insurance as a service. Official Sekure SDK for .Net</Description>
     <RepositoryUrl>https://github.com/sekure-insuretech/sekure-sdk-dotnet</RepositoryUrl>
     <PackageProjectUrl>https://api.sekure.com.co</PackageProjectUrl>


### PR DESCRIPTION
Se ha cambiado la versión del paquete en el archivo `Sekure.csproj` de `2.5.1` a `2.5.2`.