### PR TITLE
Añadir método RiskStatusByProduct y actualizar versión

### DIFF
--- a/src/Sekure/Runtime/IInsuranceOS.cs
+++ b/src/Sekure/Runtime/IInsuranceOS.cs
@@ -241,6 +241,7 @@ namespace Sekure.Runtime
         /// <param name="requestExecutable">This is the object needed to execute the function /// </param>
         /// <param name="sessionId">This is the session id with which the quote was registered /// </param>
         Task<ValidationProcess> ValidateStatus(RequestExecutable requestExecutable, Guid sessionId);
+        Task<ValidationProcess> RiskStatusByProduct(string productName, Guid sessionId);
 
         /// <summary>
         /// Gets the products assigned to the client

--- a/src/Sekure/Runtime/InsuranceOS.cs
+++ b/src/Sekure/Runtime/InsuranceOS.cs
@@ -721,6 +721,22 @@ namespace Sekure.Runtime
             });
             return executableRiskValidator;
         }
+
+        public async Task<ValidationProcess> RiskStatusByProduct(string productName, Guid sessionId)
+        {
+            HttpResponseMessage response = await GetClient().GetAsync($"{apiUrl}/SKR/RiskStatusByProduct/{productName}/{sessionId}");
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new Exception($"statusCode: {response.StatusCode}, messageException: {response.Content.ReadAsStringAsync().Result}");
+            }
+            string responseJson = await response.Content.ReadAsStringAsync();
+            ValidationProcess executableRiskValidator = JsonConvert.DeserializeObject<ValidationProcess>(responseJson, new JsonSerializerSettings
+            {
+                NullValueHandling = NullValueHandling.Ignore,
+                DefaultValueHandling = DefaultValueHandling.Ignore
+            });
+            return executableRiskValidator;
+        }
         #endregion
     }
 }

--- a/src/Sekure/Sekure.csproj
+++ b/src/Sekure/Sekure.csproj
@@ -6,7 +6,7 @@
     <Copyright>2025</Copyright>
     <PackageTags>Insurance</PackageTags>
     <PackageIcon>logo.png</PackageIcon>
-    <Version>2.5.2</Version>
+    <Version>2.5.3</Version>
     <Description>Insurance as a service. Official Sekure SDK for .Net</Description>
     <RepositoryUrl>https://github.com/sekure-insuretech/sekure-sdk-dotnet</RepositoryUrl>
     <PackageProjectUrl>https://api.sekure.com.co</PackageProjectUrl>


### PR DESCRIPTION
Se ha añadido un nuevo método `RiskStatusByProduct` en la interfaz `IInsuranceOS.cs` para obtener el estado del riesgo por producto. Este método se implementa en `InsuranceOS.cs`, realizando una llamada HTTP a la API y manejando errores en la respuesta.

Además, se ha actualizado la versión del paquete en `Sekure.csproj` de `2.5.2` a `2.5.3`.