### PR TITLE
Actualiza tiempo de espera y versión del paquete

### DIFF
--- a/src/Sekure/Runtime/InsuranceOS.cs
+++ b/src/Sekure/Runtime/InsuranceOS.cs
@@ -37,6 +37,7 @@ namespace Sekure.Runtime
         {
             _client.DefaultRequestHeaders.Add("skr-key", apiKey);
             _client.DefaultRequestHeaders.Add("client-ip-address", clientIpAddress);
+            _client.Timeout = TimeSpan.FromMinutes(5);
             return _client;
         }
 

--- a/src/Sekure/Sekure.csproj
+++ b/src/Sekure/Sekure.csproj
@@ -6,7 +6,7 @@
     <Copyright>2025</Copyright>
     <PackageTags>Insurance</PackageTags>
     <PackageIcon>logo.png</PackageIcon>
-    <Version>2.5.3</Version>
+    <Version>2.5.4</Version>
     <Description>Insurance as a service. Official Sekure SDK for .Net</Description>
     <RepositoryUrl>https://github.com/sekure-insuretech/sekure-sdk-dotnet</RepositoryUrl>
     <PackageProjectUrl>https://api.sekure.com.co</PackageProjectUrl>


### PR DESCRIPTION
Se ha añadido un tiempo de espera de 5 minutos para el cliente HTTP en el método `GetClient()` de la clase `InsuranceOS.cs`.

Además, se ha actualizado la versión del paquete en `Sekure.csproj` de `2.5.3` a `2.5.4`, manteniendo otros metadatos del paquete.